### PR TITLE
Allow compilation on OpenCL 1.1 headers

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -16,9 +16,11 @@ namespace vram {
 
         // Fill buffer with zeros
         static int clear_buffer(const cl::Buffer& buf) {
+#ifdef CL_VERSION_1_2
             if (has_fillbuffer)
                 return queue.enqueueFillBuffer(buf, 0, 0, block::size, nullptr, nullptr);
             else
+#endif
                 return queue.enqueueCopyBuffer(zero_buffer, buf, 0, 0, block::size, nullptr, nullptr);
         }
 
@@ -39,10 +41,12 @@ namespace vram {
                 context = cl::Context(gpu_devices);
                 queue = cl::CommandQueue(context, device);
 
+#ifdef CL_VERSION_1_2
                 cl_uint version = cl::detail::getPlatformVersion(platform());
 
                 if (version >= (1 << 16 | 2))
                     has_fillbuffer = true;
+#endif
 
                 if (!has_fillbuffer) {
                     char zero_data[block::size] = {};


### PR DESCRIPTION
Wrap enqueueFillBuffer and 1.2 platform detection into ifdefs for
CL_VERSION_1_2, which is only available when usin 1.2 headers (or
later).
