### PR TITLE
Prevent process pages from being swapped

### DIFF
--- a/src/vramfs.cpp
+++ b/src/vramfs.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <limits>
 #include <regex>
+#include <sys/mman.h>
 
 // Internal dependencies
 #include "vramfs.hpp"
@@ -527,6 +528,11 @@ int main(int argc, char* argv[]) {
 
     if (argc == 5 || argc == 6) {
         memory::set_device(atoi(argv[4]));
+    }
+
+    // Lock process pages in memory to prevent them from being swapped
+    if (mlockall(MCL_CURRENT | MCL_FUTURE)) {
+        std::cerr << "failed to lock process pages in memory, vramfs may freeze if swapped" << std::endl;
     }
 
     // Check for OpenCL supported GPU and allocate memory


### PR DESCRIPTION
Closes: https://github.com/Overv/vramfs/issues/31

Seems to work, tests done:

1. Create high memory pressure via `stress --vm 20 --vm-bytes 1024M --vm-hang 1`
2. Set swappiness to max `echo "200" | sudo tee /proc/sys/vm/swappiness`
3. Launch vramfs with and without the fix (in this case with root privileges and without, as it can't protect pages without root)
4. Check the resulting processes `/proc/<PID>/status`

Results:
1. Process with protection:
```
VmSwap:	       0 kB
```
2. Proces without protection:
```
VmSwap:	       784 kB
```

Signed-off-by: Atrate <Atrate@protonmail.com>